### PR TITLE
Use msgpack::type::FLOAT instead of msgpack::type::DOUBLE.

### DIFF
--- a/autobahn/autobahn_impl.hpp
+++ b/autobahn/autobahn_impl.hpp
@@ -537,7 +537,7 @@ namespace autobahn {
          case msgpack::type::BOOLEAN:
             return boost::any(obj.as<bool>());
 
-         case msgpack::type::DOUBLE:
+         case msgpack::type::FLOAT:
             return boost::any(obj.as<double>());
 
          case msgpack::type::NIL:


### PR DESCRIPTION
The DOUBLE type has been deprecated; see
https://github.com/msgpack/msgpack-c/wiki/cpp_configure

This addresses https://github.com/tavendo/AutobahnCpp/issues/30