### PR TITLE
Interfaces for discussion about transport abstraction.

### DIFF
--- a/autobahn/wamp_transport.hpp
+++ b/autobahn/wamp_transport.hpp
@@ -1,0 +1,119 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2014 Tavendo GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef AUTOBAHN_WAMP_TRANSPORT_HPP
+#define AUTOBAHN_WAMP_TRANSPORT_HPP
+
+// http://stackoverflow.com/questions/22597948/using-boostfuture-with-then-continuations/
+#define BOOST_THREAD_PROVIDES_FUTURE
+#define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
+#define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
+
+#include <boost/thread/future.hpp>
+#include <memory>
+#include <string>
+
+namespace autobahn {
+
+class wamp_message;
+class wamp_transport_handler;
+
+/*!
+ * Provides an abstraction for a transport to be used by the session. A wamp
+ * transport is defined as being message based, bidirectional, reliable, and
+ * ordered.
+ */
+class wamp_transport
+{
+public:
+    /*!
+     * Default constructor.
+     */
+    wamp_transport() = default;
+
+    /*!
+     * Default virtual destructor.
+     */
+    virtual ~wamp_transport() = default;
+
+    wamp_transport(const wamp_transport&) = delete;
+    wamp_transport& operator=(const wamp_transport&) = delete;
+    wamp_transport(wamp_transport&&) = delete;
+    wamp_transport& operator=(wamp_transport&&) = delete;
+
+    /*!
+     * Attempts to connect the transport.
+     *
+     * @return A future that will be satisfied when the connect attempt
+     *         has been made.
+     */
+    virtual boost::future<void> connect() = 0;
+
+    /*!
+     * Attempts to disconnect the transport.
+     *
+     * @return A future that will be satisfied when the disconnect attempt
+     *         has been made.
+     */
+    virtual boost::future<void> disconnect() = 0;
+
+    /*!
+     * Determines if the transport is connected.
+     *
+     * @return Whether or not the transport is connected.
+     */
+    virtual bool is_connected() const = 0;
+
+    /*!
+     * Attaches a handler to the transport. Only one handler may
+     * be attached at any given time.
+     *
+     * @param handler The handler to attach to this transport.
+     *
+     * @return A future that will be satisfied when the transport
+     *         handler has been successfully attached.
+     */
+    virtual void attach(
+            const std::shared_ptr<wamp_transport_handler>& handler) = 0;
+
+    /*!
+     * Detaches the handler currently attached to the transport.
+     *
+     * @return A future that will be satisfied when the transport
+     *         handler has been successfully detached.
+     */
+    virtual void detach() = 0;
+
+    /*!
+     * Determines if the transport has a handler attached.
+     *
+     * @return Whether or not a handler is attached.
+     */
+    virtual bool has_handler() const = 0;
+
+    /*!
+     * Send the message synchronously over the transport.
+     *
+     * @param message The message to be sent.
+     */
+    virtual void send(const std::shared_ptr<wamp_message>& message) = 0;
+};
+
+} // namespace autobahn
+
+#endif // AUTOBAHN_WAMP_TRANSPORT_HPP

--- a/autobahn/wamp_transport_handler.hpp
+++ b/autobahn/wamp_transport_handler.hpp
@@ -1,0 +1,83 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2014 Tavendo GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef AUTOBAHN_WAMP_TRANSPORT_HANDLER_HPP
+#define AUTOBAHN_WAMP_TRANSPORT_HANDLER_HPP
+
+// http://stackoverflow.com/questions/22597948/using-boostfuture-with-then-continuations/
+#define BOOST_THREAD_PROVIDES_FUTURE
+#define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
+#define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
+
+#include "wamp_message.hpp"
+
+#include <boost/thread/future.hpp>
+#include <memory>
+#include <string>
+
+namespace autobahn {
+
+class wamp_transport;
+
+/*!
+ * Provides an abstraction for associating a handler with a transport.
+ */
+class wamp_transport_handler
+{
+public:
+    /*!
+     * Default constructor.
+     */
+    wamp_transport_handler() = default;
+
+    /*!
+     * Default virtual destructor.
+     */
+    virtual ~wamp_transport_handler() = default;
+
+    wamp_transport_handler(const wamp_transport_handler&) = delete;
+    wamp_transport_handler& operator=(const wamp_transport_handler&) = delete;
+    wamp_transport_handler(wamp_transport_handler&&) = delete;
+    wamp_transport_handler& operator=(wamp_transport_handler&&) = delete;
+
+    /*!
+     * Called by the transport when attaching a handler.
+     *
+     * @param transport The transport being attached to.
+     */
+    virtual void on_attach(const std::shared_ptr<wamp_transport>& transport) = 0;
+
+    /*!
+     * Called by the transport when detaching a handler.
+     *
+     * @param was_clean Whether or not the transport is cleanly detaching.
+     * @param reason The reason for detaching.
+     */
+    virtual void on_detach(bool was_clean, const std::string& reason) = 0;
+
+    /*!
+     * Called by the transport when a message is received.
+     *
+     * @param message The message that has been received.
+     */
+    virtual void on_message(const wamp_message& message) = 0;
+};
+
+} // namespace autobahn
+
+#endif // AUTOBAHN_WAMP_TRANSPORT_HANDLER_HPP


### PR DESCRIPTION
@oberstet Here are the interfaces that we discussed. Need to further understand the intent of how the on_attach and on_detach are supposed to work.

My main concern right now is that the session is not in a state where it could be reused due to all of the promises, and internal state that would need to be properly dealt with. I am considering actually leaving out the `on_attach` and `on_detach` pieces for the time being and still just pass the transport into the session constructor. An incremental step from there would be to remove the transport from the session constructor and add in the attach and detach semantics.

I would say that I am about 90% complete the first iteration that doesn't include the `on_attach` and `on_detach` methods in the handler.